### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,42 @@
-# CI to build and test. Copied from github.com/fxamacker/cbor
+# CI to build and test.
+# Based on https://github.com/x448/float16/blob/master/.github/workflows/ci.yml
 name: CI
 
+# Revoke default permissions.
+permissions: {}
+
 on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]  
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-  workflow_dispatch:
+    tags:
+      - 'v*'
 
 jobs:
-
-  # Test on various OS with default Go version. 
+  # Test on various OS with some Go versions. 
   tests:
-    name: Test on ${{matrix.os}}
+    name: test ${{matrix.os}} go-${{ matrix.go-version }}
     runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: read
+
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        go-version: [1.16, 1.17, 1.18]
         
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
         
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
         


### PR DESCRIPTION
Remove default permissions.
Grant minimum permission required to build and test.
Add Go version to job name.
Add windows-latest.
Add Go 1.18.

Based on improvements by @x448 in github.com/x448/float16