### PR TITLE
Bump safer-golangci-lint.yml to 1.51.1

### DIFF
--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -6,29 +6,34 @@
 #
 # safer-golangci-lint.yml
 #
-# 100% of the script for downloading, installing, and running golangci-lint
-# is embedded in this file.  The embedded SHA384 digest is used to verify the 
-# downloaded golangci-lint tarball (golangci-lint-1.46.2-linux-amd64.tar.gz). 
+# This workflow downloads, verifies, and runs golangci-lint in a
+# deterministic, reviewable, and safe manner.
 #
 # To use:
-#   Step 1. Copy this file into [github_repo]/.github/workflows/
+#   Step 1. Copy this file into [your_github_repo]/.github/workflows/
 #   Step 2. There's no step 2 if you like the default settings.
 #
-# Create and use a config file (.golangci.yml) as described in golangci-lint docs.
+# See golangci-lint docs for more info at
+# https://github.com/golangci/golangci-lint
+#
+# 100% of the script for downloading, installing, and running golangci-lint
+# is embedded in this file. The embedded SHA-256 digest is used to verify the
+# downloaded golangci-lint tarball (golangci-lint-1.xx.x-linux-amd64.tar.gz).
+#
+# The embedded SHA-256 digest matches golangci-lint-1.xx.x-checksums.txt at
+# https://github.com/golangci/golangci-lint/releases
 #
 # To use a newer version of golangci-lint, change these values:
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.46.2 (May 19, 2022)
-#   - actions/setup-go uses check-latest: true
-#   - Remove default permissions at top level and grant only read permission in the job.
-#   - Add workflow_dispatch.
-#   - Tidy some comments.
-#   - Bump golangci-lint to 1.46.2.
-#   - Checksum for golangci-lint-1.46.2-linux-amd64.tar.gz
-#     - SHA-256 is 242cd4f2d6ac0556e315192e8555784d13da5d1874e51304711570769c4f2b9b
-#     - SHA-384 is 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
+# Release v1.51.1 (February 5, 2023)
+#   - Bump golangci-lint to 1.51.1
+#   - Shuffle some comments
+#   - Hash of golangci-lint-1.50.1-linux-amd64.tar.gz
+#     - SHA-256: 17aeb26c76820c22efa0e1838b0ab93e90cfedef43fbfc9a2f33f27eb9e5e070
+#                This SHA-256 digest matches golangci-lint-1.51.1-checksums.txt at
+#                https://github.com/golangci/golangci-lint/releases
 #
 name: linters
 
@@ -43,11 +48,12 @@ on:
     branches: [main, master]
 
 env:
-  GOLINTERS_VERSION: 1.46.2
+  GO_VERSION: 1.19
+  GOLINTERS_VERSION: 1.51.1
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
-  GOLINTERS_TIMEOUT: 5m
-  OPENSSL_DGST_CMD: openssl dgst -sha384 -r
+  GOLINTERS_TGZ_DGST: 17aeb26c76820c22efa0e1838b0ab93e90cfedef43fbfc9a2f33f27eb9e5e070
+  GOLINTERS_TIMEOUT: 15m
+  OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
 
 jobs:
@@ -65,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
       - name: Install golangci-lint


### PR DESCRIPTION
Bump safer-golangci-lint.yml to 1.51.1:
- Bump golangci-lint to 1.51.1.
- Bump go to 1.19.x.