### PR TITLE
Update govulncheck.yml

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -9,9 +9,6 @@ permissions: {}
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run at least once daily because vulnerability database might be updated.
-    - cron: '30 15 * * *'
   pull_request:
     paths:
       - '**'
@@ -22,28 +19,29 @@ on:
       - '!**.md'
     branches:
       - 'main'
+      - 'master'
       - 'release*'
+      - 'feature/stream-mode'
     tags:
       - 'v*'
 
 jobs:
-  vulncheck:
+  Check:
     runs-on: ubuntu-latest
     permissions:
       # Grant permission to read content.
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 1
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
     - name: Install latest from golang.org
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
-    - name: Run govulncheck
-      # Use -v flag to print a full call stack for each vulnerability found.
-      run: govulncheck -v ./...
+      run: go install golang.org/x/vuln/cmd/govulncheck@5507063454b1b8c930db99818a88b52f1f143418 # v1.0.4
+    - name: Run govulncheck      
+      run: govulncheck -show=traces ./...


### PR DESCRIPTION
Replace obsolete and broken govulncheck.yml with newer working copy from https://github.com/fxamacker/cbor

This bumps govulncheck to 1.0.4 and pins dependencies.