### PR TITLE
Create .golangci.yml and lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,88 @@
+# Do not delete linter settings. Linters like gocritic can be enabled on the command line.
+
+linters-settings:
+  depguard:
+    rules:
+      prevent_unmaintained_packages:
+        list-mode: strict 
+        files:
+          - $all
+          - "!$test"
+        allow:
+          - $gostd
+        deny:
+          - pkg: io/ioutil
+            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    ignore-tests: true
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - commentedOutCode
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - paramTypeCombine
+      - whyNoLint
+      - wrapperFunc
+  gofmt:
+    simplify: false
+  goimports:
+    local-prefixes: github.com/fxamacker/circlehash
+  golint:
+    min-confidence: 0
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  staticcheck:
+    checks: ["all"]
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bidichk
+    - depguard
+    - errcheck
+    - exportloopref
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nilerr
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+
+issues:
+  # max-issues-per-linter default is 50.  Set to 0 to disable limit.
+  max-issues-per-linter: 0
+  # max-same-issues default is 3.  Set to 0 to disable limit.
+  max-same-issues: 0
+

--- a/circlehash64.go
+++ b/circlehash64.go
@@ -37,7 +37,7 @@ func Hash64(b []byte, seed uint64) uint64 {
 	if len(b) > 64 {
 		fn = circle64f
 	}
-	return uint64(fn(*(*unsafe.Pointer)(unsafe.Pointer(&b)), seed, uint64(len(b))))
+	return fn(*(*unsafe.Pointer)(unsafe.Pointer(&b)), seed, uint64(len(b)))
 }
 
 // Hash64String returns a 64-bit digest of s.
@@ -47,7 +47,7 @@ func Hash64String(s string, seed uint64) uint64 {
 	if len(s) > 64 {
 		fn = circle64f
 	}
-	return uint64(fn(*(*unsafe.Pointer)(unsafe.Pointer(&s)), seed, uint64(len(s))))
+	return fn(*(*unsafe.Pointer)(unsafe.Pointer(&s)), seed, uint64(len(s)))
 }
 
 // Hash64Uint64x2 returns a 64-bit digest of a and b.

--- a/circlehash64_test.go
+++ b/circlehash64_test.go
@@ -126,7 +126,7 @@ func TestCircleHash64NonUniformBitPatternInputs(t *testing.T) {
 
 	// Verify CircleHash64 digests produced from hashing portions of
 	// data using different seed values. Input sizes vary from
-	// 1 to 16384 bytes by varing starting pos and ending pos.
+	// 1 to 16384 bytes by varying starting pos and ending pos.
 
 	testCases := []struct {
 		name                     string


### PR DESCRIPTION
Create .golangci.yml to enable and run more linters than what is enabled by default.
Resolve issues found by extra linters.