### PR TITLE
Enable gocritic and lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
   depguard:
     rules:
       prevent_unmaintained_packages:
-        list-mode: strict 
+        list-mode: strict
         files:
           - $all
           - "!$test"
@@ -63,6 +63,7 @@ linters:
     - errcheck
     - exportloopref
     - goconst
+    - gocritic
     - gocyclo
     - gofmt
     - goimports

--- a/circlehash64.go
+++ b/circlehash64.go
@@ -139,7 +139,7 @@ func circle64f(p unsafe.Pointer, seed uint64, dlen uint64) uint64 {
 			p = add(p, 64)
 		}
 
-		currentState = currentState ^ duplicatedState
+		currentState ^= duplicatedState
 	}
 
 	// We have at most 64 bytes to process.

--- a/circlehash64_test.go
+++ b/circlehash64_test.go
@@ -294,7 +294,7 @@ func TestCircleHash64NonUniformBitPatternInputs(t *testing.T) {
 // digests using input of repeated byte values (0x00 to 0xFF).
 // Input sizes range from 1 to 256 bytes.
 func checksumUniformBitPatternInputs(t *testing.T, seed uint64) []byte {
-	sha512 := sha512.New()
+	h := sha512.New()
 
 	// Check 65536 digests on uniform byte fills (0x00-0xFF) of varying lengths
 	for pattern := 0; pattern <= 255; pattern++ {
@@ -311,11 +311,11 @@ func checksumUniformBitPatternInputs(t *testing.T, seed uint64) []byte {
 			binary.LittleEndian.PutUint64(b, digest)
 
 			// Feed CircleHash64 result into SHA-512.
-			sha512.Write(b)
+			h.Write(b)
 		}
 	}
 
-	return sha512.Sum(nil)
+	return h.Sum(nil)
 }
 
 // checksumVaryingStartPos updates cryptoHash512 with


### PR DESCRIPTION
Update .golangci-lint.yml to enable gocritic and resolve 2 detected coding style issues (does not affect hash digest).