### PR TITLE
Bump govulncheck from 1.0.4 to v1.1.3

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -42,6 +42,6 @@ jobs:
         go-version: 1.21.x
         check-latest: true
     - name: Install latest from golang.org
-      run: go install golang.org/x/vuln/cmd/govulncheck@5507063454b1b8c930db99818a88b52f1f143418 # v1.0.4
+      run: go install golang.org/x/vuln/cmd/govulncheck@4ea4418106cea3bb2c9aa098527c924e9e1fbbb4 # v1.1.3
     - name: Run govulncheck      
       run: govulncheck -show=traces ./...


### PR DESCRIPTION
Update govulncheck.yml to latest version of govulncheck.

Available versions of govulncheck:
- https://go.googlesource.com/vuln/+refs