### PR TITLE
.github: update GitHub Workflows

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥100%
+name: cover 100%
 
 # Remove default permissions.
 permissions: {}
@@ -44,6 +44,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
+        # Support for go1.16 (*_oldgo.go) is deprecated as of Sunday,l Oct 6, 2024 so it won't be checked.
+        # Coverage test will fail if it drops below 100% and we only need one version of Go here.
         go-version: 1.23
         check-latest: true
     - name: Install x448/float16

--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -1,7 +1,7 @@
-# Copyright 2020-present Montgomery Edwards⁴⁴⁸ (github.com/x448).
+# Copyright 2020-2023 Montgomery Edwards⁴⁴⁸ (github.com/x448).
 # This file is licensed under the MIT License. See LICENSE at https://github.com/x448/workflows for the full text.
 #
-# CI Go Cover 2020.1.28.
+# CI Go Cover 2023.5.14.
 # This GitHub Actions workflow checks if Go (Golang) code coverage satisfies the required minimum.
 # The required minimum is specified in the workflow name to keep badge.svg and verified minimum in sync.
 #
@@ -14,41 +14,40 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover 100%
+name: cover ≥100%
 
 # Remove default permissions.
 permissions: {}
 
-on: [push]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   # Verify minimum coverage is reached using `go test -short -cover` on latest-ubuntu with default version of Go.
   # The grep expression can't be too strict, it needed to be relaxed to work with different versions of Go.
   cover:
-    name: Coverage on ${{matrix.os}}
+    name: Coverage
     permissions:
       contents: read
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # Only need one OS
-        # Need at least one Go <= 1.16 until *_oldgo.go is removed or changes its build tag
-        # Need at least one Go >= 1.17 until build tags require newer version or are removed
-        os: [ubuntu-latest]
-        go-version: [1.16.x, 1.17.x]
-
+    runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5.0.2
-      with:
-        go-version: ${{ matrix.go-version }}
-        check-latest: true
-
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+    - name: Install Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        fetch-depth: 1
-
+        go-version: 1.23
+        check-latest: true
+    - name: Install x448/float16
+      run: go get github.com/x448/float16@v0.8.4
     - name: Go Coverage
       run: |
         go version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ on:
     branches: [ main ]  
   push:
     branches: [ main ]
-    tags:
-      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   # Test on various OS with some Go versions. 
@@ -26,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: [1.17, '1.20', 1.21, 1.22]
+        go-version: [1.17, 1.22, 1.23] # Test on go1.17 and latest 2 versions
         
     steps:
     - name: Install Go

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,6 +1,6 @@
 # GitHub Actions workflow for govulncheck.
 # This file is licensed under MIT License.
-# Copied from https://github.com/fxamacker/cbor
+# https://github.com/fxamacker/cbor
 
 name: govulncheck
 
@@ -10,20 +10,16 @@ permissions: {}
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '**'
-      - '!**.md'
+      # Run on pull request for all branches.
   push:
-    paths:
-      - '**'
-      - '!**.md'
     branches:
-      - 'main'
-      - 'master'
-      - 'release*'
-      - 'feature/stream-mode'
-    tags:
-      - 'v*'
+      # Run on push for all branches.
+  schedule:
+    - cron: '45 12 * * 0' # Run daily at 12:45 UTC / 7:45 AM Central.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   Check:
@@ -33,15 +29,18 @@ jobs:
       contents: read
     steps:
     - name: Checkout source
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       with:
         fetch-depth: 1
-    - name: Set up Go
+
+    - name: Install Go and setup env
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.21.x
+        go-version: 1.23
         check-latest: true
-    - name: Install latest from golang.org
+ 
+    - name: Install latest govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@4ea4418106cea3bb2c9aa098527c924e9e1fbbb4 # v1.1.3
-    - name: Run govulncheck      
+
+    - name: Run govulncheck
       run: govulncheck -show=traces ./...

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -17,12 +17,16 @@ on:
 
 env:
   GO_VERSION: '1.22'
-  GOLINTERS_VERSION: 1.56.2
+  GOLINTERS_VERSION: 1.59.1
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: e1c313fb5fc85a33890fdee5dbb1777d1f5829c84d655a47a55688f3aad5e501
+  GOLINTERS_TGZ_DGST: c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791
   GOLINTERS_TIMEOUT: 15m
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   main:
@@ -32,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout source
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Updated ci.yml, ci-go-cover.yml, govulncheck.yml, and safer-golangci-lint.yml.

### Changes to ci.yml:
- Add concurrency group.
- Run on all tags on push.
- Test go1.17 + latest 2 versions (go1.22 and go1.23).

### Changes to ci-go-cover.yml
- Copy latest ci-go-cover.yml from https://github.com/fxamacker/cbor
  - Bump go to go1.23.
  - Add concurrency group.
  - Pin dependencies.

### Changes to govulncheck.yml
- Run on all pull requests for all branches.
- Run on all push for all branches.
- Run daily at 12:45 UTC / 7:45 AM Central.
- Add concurrency group.
- Bump go to go1.23.

### Changes to safer-golangci-lint.yml
- Copy latest yml from https://github.com/fxamacker/cbor
  - Bump golangci-lint to 1.59.1.
  - Bump go to go1.22.
  - Add concurrency group.

@x448 PTAL :pray: 